### PR TITLE
Feature add minor changes

### DIFF
--- a/tour/content/basics.article
+++ b/tour/content/basics.article
@@ -14,13 +14,6 @@ El programa que se muestra a la derecha está usando los paquetes con rutas de i
 
 Por convención, el nombre del paquete es el mismo que el último elemento de la ruta de importación. Por ejemplo, el paquete `"math/rand"` comprende archivos que comienzan con la declaración `package`rand`. En cambio `"math"` viene siendo parte de la ruta donde se encuentra el paquete y a su vez tambien puede ser un paquete que comprende archivos que comienzan con la declaración `package`math`.
 
-#appengine: *Nota:* El entorno en el que se ejecutan estos programas es
-#appengine: determinista, por lo que cada vez que ejecute el programa de ejemplo
-#appengine: `rand.Intn` devolverá el mismo número.
-#appengine:
-#appengine: (Para ver un número diferente, inicie el generador de números; ver [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
-#appengine: El tiempo es constante en el playground, por lo que deberá usar otra cosa como semilla.)
-
 .play basics/packages.go
 
 * Importaciones

--- a/tour/content/basics.article
+++ b/tour/content/basics.article
@@ -109,7 +109,7 @@ Como se muestra en el ejemplo de la derecha se inicializan sin tipo.
 
 .play basics/variables-with-initializers.go
 
-* Declaración corta de variables 
+* Declaración corta de variables
 
 Sólo dentro de una función, la declaración de asignación corta `:=` se puede usar en lugar de una declaración `var` con tipo implícito.
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -50,15 +50,15 @@ El tour está disponible en otros idiomas:
 - [[https://go.dev/tour/][English - English]] (versión original)
 - [[https://go-tour-br.appspot.com/][Brazilian Portuguese — Português do Brasil]]
 - [[https://go-tour-ca.appspot.com/][Catalan — Català]]
-- [[https://tour.go-zh.org/][Simplified Chinese — 中文（简体）]]
 - [[https://go-tour-cz.appspot.com/][Czech — Česky]]
 - [[https://go-tour-id2.appspot.com/][Indonesian — Bahasa Indonesia]]
 - [[https://go-tour-jp.appspot.com/][Japanese — 日本語]]
 - [[https://go-tour-ko.appspot.com/][Korean — 한국어]]
+- [[https://go-tour-lat.appspot.com/][Spanish — Español]]
 - [[https://go-tour-pl1.appspot.com/][Polish — Polski]]
 - [[https://go-tour-th.appspot.com/][Thai — ภาษาไทย]]
 - [[https://go-tour-ua-translation.lm.r.appspot.com/][Ukrainian — Українською]]
-- [[https://go-tour-lat.appspot.com/][Spanish — Español]]
+- [[https://tour.go-zh.org/][Simplified Chinese — 中文（简体）]]
 
 Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]] o presiona `PageDown` para continuar.
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -80,25 +80,25 @@ Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]
 #appengine:
 #appengine: Por supuesto, puedes continuar haciendo el tour a través de este sitio web.
 
-#appengine: * Go Playground
-#appengine:
-#appengine: Este tour esta construido sobre [[https://play.golang.org/][Go Playground]],
-#appengine: un servicio web que se ejecuta en los servidores de [[https://golang.org/][golang.org]].
-#appengine:
-#appengine: El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro
-#appengine: de una zona de pruebas,luego devuelve la salida.
-#appengine:
-#appengine: Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
-#appengine:
-#appengine: - En el playground, el tiempo empieza en el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
-#appengine:
-#appengine: - También hay limitaciones en el tiempo de ejecución, el uso de CPU y memoria, y el programa no puede acceder a hosts de red externos.
-#appengine:
-#appengine: El playground utiliza la última version estable de Go.
-#appengine:
-#appengine: Lee "[[https://blog.golang.org/playground][Inside the Go Playground]]" para aprender más.
-#appengine:
-#appengine: .play welcome/sandbox.go
+* Go Playground
+
+Este tour esta construido sobre [[https://play.golang.org/][Go Playground]],
+un servicio web que se ejecuta en los servidores de [[https://golang.org/][golang.org]].
+
+El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro
+de una zona de pruebas,luego devuelve la salida.
+
+Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
+
+- En el playground, el tiempo empieza en el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
+
+- También hay limitaciones en el tiempo de ejecución, el uso de CPU y memoria, y el programa no puede acceder a hosts de red externos.
+
+El playground utiliza la última version estable de Go.
+
+Lee "[[https://blog.golang.org/playground][Inside the Go Playground]]" para aprender más.
+
+.play welcome/sandbox.go
 
 * ¡Felicitaciones!
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -82,7 +82,7 @@ Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]
 
 #appengine: * Go Playground
 #appengine:
-#appengine: Este tour esta construido sobre [[https://play.golang.org/][Go Playground]], 
+#appengine: Este tour esta construido sobre [[https://play.golang.org/][Go Playground]],
 #appengine: un servicio web que se ejecuta en los servidores de [[https://golang.org/][golang.org]].
 #appengine:
 #appengine: El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro
@@ -90,7 +90,7 @@ Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]
 #appengine:
 #appengine: Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
 #appengine:
-#appengine: - En el playground, el tiempo empieza en el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista. 
+#appengine: - En el playground, el tiempo empieza en el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
 #appengine:
 #appengine: - También hay limitaciones en el tiempo de ejecución, el uso de CPU y memoria, y el programa no puede acceder a hosts de red externos.
 #appengine:

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -80,24 +80,24 @@ Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]
 #appengine:
 #appengine: Por supuesto, puedes continuar haciendo el tour a través de este sitio web.
 
-* Go Playground
-
-Este tour esta construido sobre [[https://play.golang.org/][Go Playground]],
-un servicio web que se ejecuta en los servidores de [[https://golang.org/][golang.org]].
-
-El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro de una zona de pruebas, luego devuelve la salida.
-
-Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
-
-- En el playground, el tiempo empieza el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
-
-- También hay limitaciones en el tiempo de ejecución, el uso de CPU y memoria, y el programa no puede acceder a hosts de red externos.
-
-El playground utiliza la última version estable de Go.
-
-Lee "[[https://blog.golang.org/playground][Inside the Go Playground]]" para aprender más.
-
-.play welcome/sandbox.go
+#appengine: * Go Playground
+#appengine:
+#appengine: Este tour esta construido sobre [[https://play.golang.org/][Go Playground]],
+#appengine: un servicio web que se ejecuta en los servidores de [[https://golang.org/][golang.org]].
+#appengine:
+#appengine: El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro de una zona de pruebas, luego devuelve la salida.
+#appengine:
+#appengine: Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
+#appengine:
+#appengine: - En el playground, el tiempo empieza el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
+#appengine:
+#appengine: - También hay limitaciones en el tiempo de ejecución, el uso de CPU y memoria, y el programa no puede acceder a hosts de red externos.
+#appengine:
+#appengine: El playground utiliza la última version estable de Go.
+#appengine:
+#appengine: Lee "[[https://blog.golang.org/playground][Inside the Go Playground]]" para aprender más.
+#appengine:
+#appengine: .play welcome/sandbox.go
 
 * ¡Felicitaciones!
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -89,7 +89,7 @@ El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro
 
 Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
 
-- En el playground, el tiempo empieza en el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
+- En el playground, el tiempo empieza el 2009-11-10 23:00:00 UTC (determinar el significado de esta fecha es un ejercicio para el lector). Esto facilita el almacenamiento en caché de los programas al proporcionarles una salida determinista.
 
 - También hay limitaciones en el tiempo de ejecución, el uso de CPU y memoria, y el programa no puede acceder a hosts de red externos.
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -39,7 +39,7 @@ en el botón [[javascript:highlightAndClick(".syntax-checkbox")][sintaxis]].
 
 Cuando estés listo para avanzar, haz clic en la [[javascript:highlightAndClick(".next-page")][flecha derecha]] abajo o presiona la tecla `PageDown`.
 
-Traducción realizada por la comunidad de [[https://github.com/gophers-latam/go-tour-es/][Gophers-Latam]].
+Traducción realizada por la comunidad de [[https://github.com/gophers-latam/go-tour-es/][Gophers LATAM]].
 
 .play welcome/hello.go
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -85,8 +85,7 @@ Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]
 Este tour esta construido sobre [[https://play.golang.org/][Go Playground]],
 un servicio web que se ejecuta en los servidores de [[https://golang.org/][golang.org]].
 
-El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro
-de una zona de pruebas,luego devuelve la salida.
+El servicio recibe un programa Go, compila, vincula y ejecuta el programa dentro de una zona de pruebas, luego devuelve la salida.
 
 Hay limitaciones para los programas que pueden ser ejecutados dentro del playground de Go:
 

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -54,11 +54,11 @@ El tour está disponible en otros idiomas:
 - [[https://go-tour-id2.appspot.com/][Indonesian — Bahasa Indonesia]]
 - [[https://go-tour-jp.appspot.com/][Japanese — 日本語]]
 - [[https://go-tour-ko.appspot.com/][Korean — 한국어]]
-- [[https://go-tour-lat.appspot.com/][Spanish — Español]]
 - [[https://go-tour-pl1.appspot.com/][Polish — Polski]]
+- [[https://tour.go-zh.org/][Simplified Chinese — 中文（简体）]]
+- [[https://go-tour-lat.appspot.com/][Spanish — Español]]
 - [[https://go-tour-th.appspot.com/][Thai — ภาษาไทย]]
 - [[https://go-tour-ua-translation.lm.r.appspot.com/][Ukrainian — Українською]]
-- [[https://tour.go-zh.org/][Simplified Chinese — 中文（简体）]]
 
 Haz clic en el botón [[javascript:highlightAndClick(".next-page")]["siguiente"]] o presiona `PageDown` para continuar.
 


### PR DESCRIPTION
## :nerd_face:  Description

1. Change `Gophers-Latam` to `Gophers LATAM`
2. Remove white spaces
3. Add missing space after a period
4. Remove unnecessary word `en`
5. "Uncomment" Go Playground section and change required paragraphs
6. Confirm that 4 is right, _Actually, I don't know where did you take that screenshot_

## :thinking: Questions

1. Why don't we have all the sessions active in the code, but we do have them on the deployed page?
2. Not only do we translate, but we also add extras?

## 🤩 Solves

#23 